### PR TITLE
Added Dockerfile and docker example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get -y install \
+    make \
+    clang-8 \
+    lld-8 \
+    libc6-dev-i386 \
+    python3

--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@ I did not find instructions for this anywhere online, so here they are. We can n
 3. To try the built wasm file, run `python3 server.py`.
 
 Optional: To disassemble the wasm file, you can install [wabt](https://github.com/WebAssembly/wabt) and run `make wat`.
+
+## Docker
+
+The following command builds an ubuntu:18.04 image containing the dependencies needed to build the working example.
+
+```bash
+$ docker build -t clang-wasm-ubuntu:18.04 .
+```
+
+Then, you can mount the source files in a container running the image and follow the instructions above.
+
+
+```bash
+docker run --rm -it -v`pwd`:/opt/src -w /opt/src -p4242:4242 clang-wasm-ubuntu:18.04
+
+root@74a067d2c9e6:/opt/src# make
+.... <snip> ...
+root@74a067d2c9e6:/opt/src# python3 server.py
+serving at port 4242
+```


### PR DESCRIPTION
I had a lot of trouble getting the example to work on ubuntu:18.04. I ended up chasing down what I think are the minimal set of requirements to run this example. 

I've added those to a `Dockerfile` along with some [README](https://github.com/PetterS/clang-wasm/pull/5/commits/ad4749404755d2e4cca0d6ede2ac21b8104a5a27#diff-04c6e90faac2675aa89e2176d2eec7d8) documentation on how to build the image and run the example server. 